### PR TITLE
issues: add prechecks

### DIFF
--- a/.github/workflows/auto-update-db.yml
+++ b/.github/workflows/auto-update-db.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   auto_update_db:
-    if: ${{ github.event.label.name == 'add-game' || github.event.label.name == 'add-movie' }}
+    if: >-
+      (github.event.label.name == 'add-game' || github.event.label.name == 'add-movie') ||
+      (github.event.label.name == 'request-game' || github.event.label.name == 'request-movie')
     runs-on: ubuntu-latest
 
     steps:
@@ -51,8 +53,42 @@ jobs:
           python -u ./updater.py --issue_update --${{ github.event.label.name }}
           rm -f ./submission.json  # remove the submission file
 
-      # was going to create a PR instead but not really much point since we're already reviewing links
+      - name: Git Diff
+        id: diff
+        # if: ${{ github.event.label.name == 'request-game' || github.event.label.name == 'request-movie' }}
+        working-directory: database
+        run: |
+          comment=$(cat <<- EOF
+
+            ```diff
+            $(git diff)
+            ```
+          EOF
+          )
+
+          echo "${comment}" >> ../comment.md
+          echo "issue_title=$(cat ./title.md)" >> $GITHUB_OUTPUT
+
+      - name: Update Issue Title
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_BOT_TOKEN }}
+          script: |
+            github.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: ${{ steps.diff.outputs.issue_title }}
+            })
+
+      - name: Issue comment
+        uses: mshick/add-pr-comment@v2
+        with:
+          repo-token: ${{ secrets.GH_BOT_TOKEN }}
+          message-path: comment.md
+
       - name: GitHub Commit & Push
+        if: ${{ github.event.label.name == 'add-game' || github.event.label.name == 'add-movie' }}
         uses: actions-js/push@v1.4
         with:
           author_email: ${{ secrets.GH_BOT_EMAIL }}
@@ -63,6 +99,7 @@ jobs:
           message: 'resolves #${{ github.event.issue.number }}'
 
       - name: Close Issue
+        if: ${{ github.event.label.name == 'add-game' || github.event.label.name == 'add-movie' }}
         uses: peter-evans/close-issue@v2
         with:
           close-reason: completed
@@ -71,6 +108,7 @@ jobs:
           token: ${{ secrets.GH_BOT_TOKEN }}
 
       - name: Lock Issue
+        if: ${{ github.event.label.name == 'add-game' || github.event.label.name == 'add-movie' }}
         uses: OSDKDev/lock-issues@v1.1
         with:
           repo-token: ${{ secrets.GH_BOT_TOKEN }}

--- a/updater.py
+++ b/updater.py
@@ -178,6 +178,28 @@ def process_igdb_id(game_slug: Optional[str] = None,
     except KeyError as e:
         raise Exception(f'Error processing game: {e}')
     else:
+        # create the issue comment and title files
+        try:
+            args.issue_update
+        except NameError:
+            pass
+        else:
+            issue_comment = f"""
+                | Property | Value |
+                | --- | --- |
+                | title | {json_data['name']} |
+                | year | {json_data['release_dates'][0]['y']} |
+                | summary | {json_data['summary']} |
+                | id | {json_data['id']} |
+                | poster | {json_data['cover']['url']} |
+                """
+            with open("comment.md", "w") as comment_f:
+                comment_f.write(issue_comment)
+
+            issue_title = f"[GAME]: {json_data['name']} ({json_data['release_dates'][0]['y']})"
+            with open("title.md", "w") as title_f:
+                title_f.write(issue_title)
+
         # update the existing dictionary with new values from json_data
         og_data.update(json_data)
         if youtube_url:
@@ -223,6 +245,28 @@ def process_tmdb_id(tmdb_id: int, youtube_url: Optional[str] = None) -> dict:
     except KeyError as e:
         raise Exception(f'Error processing movie: {e}')
     else:
+        # create the issue comment and title files
+        try:
+            args.issue_update
+        except NameError:
+            pass
+        else:
+            issue_comment = f"""
+                | Property | Value |
+                | --- | --- |
+                | title | {json_data['title']} |
+                | year | {json_data['release_date'][0:4]} |
+                | summary | {json_data['overview']} |
+                | id | {json_data['id']} |
+                | poster | {json_data['poster_path']} |
+                """
+            with open("comment.md", "w") as comment_f:
+                comment_f.write(issue_comment)
+
+            issue_title = f"[MOVIE]: {json_data['title']} ({json_data['release_date'][0:4]})"
+            with open("title.md", "w") as title_f:
+                title_f.write(issue_title)
+
         # update the existing dictionary with new values from json_data
         og_data.update(json_data)
         if youtube_url:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Add prechecks to issues/requests. This should do the following:

- Update the issue title automatically based on the found metadata of the item
- Add a comment to the issue with metadata about the item as well as the diff of what would change.

Unable to test until this is in `master` branch.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
