### PR TITLE
issues: fix comment file append

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,7 @@ submission.json
 database/
 gh-pages-template/games/
 gh-pages-template/movies/
+
+# files from issue upating
+comment.md
+title.md

--- a/updater.py
+++ b/updater.py
@@ -191,9 +191,9 @@ def process_igdb_id(game_slug: Optional[str] = None,
 | year | {json_data['release_dates'][0]['y']} |
 | summary | {json_data['summary']} |
 | id | {json_data['id']} |
-| poster | ![poster]({json_data['cover']['url'].replace('/t_original/', '/t_cover_big/')}) |
+| poster | ![poster](https:{json_data['cover']['url'].replace('/t_thumb/', '/t_cover_big/')}) |
 """
-            with open("comment.md", "w") as comment_f:
+            with open("comment.md", "a") as comment_f:
                 comment_f.write(issue_comment)
 
             issue_title = f"[GAME]: {json_data['name']} ({json_data['release_dates'][0]['y']})"
@@ -260,7 +260,7 @@ def process_tmdb_id(tmdb_id: int, youtube_url: Optional[str] = None) -> dict:
 | id | {json_data['id']} |
 | poster | ![poster](https://image.tmdb.org/t/p/w185{json_data['poster_path']}) |
 """
-            with open("comment.md", "w") as comment_f:
+            with open("comment.md", "a") as comment_f:
                 comment_f.write(issue_comment)
 
             issue_title = f"[MOVIE]: {json_data['title']} ({json_data['release_date'][0:4]})"
@@ -348,8 +348,8 @@ def check_youtube(data: dict):
             )
         except youtube_dl.utils.DownloadError as e:
             print(f'Error processing youtube url: {e}')
-            with open("comment.md", "a") as exceptions_f:
-                exceptions_f.write(f'\n\n:warning: **Exception Occurred** :warning:\n {e}')
+            with open("comment.md", "w") as exceptions_f:
+                exceptions_f.write(f'# :bangbang: **Exception Occurred** :bangbang:\n\n```txt\n{e}\n```\n\n')
         else:
             if 'entries' in result:
                 # Can be a playlist or a list of videos


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fixes comment file append. YouTube url is processed first, so this should be in write mode, while the game/movie is processed next so those should be in append mode.

Additionally, fixes an issue with the igdb poster image in the comment.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
