### PR TITLE
formatting: fix various format issues

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -193,14 +193,14 @@ def process_igdb_id(game_slug: Optional[str] = None,
             if args.issue_update:
                 # create the issue comment and title files
                 issue_comment = f"""
-    | Property | Value |
-    | --- | --- |
-    | title | {json_data['name']} |
-    | year | {json_data['release_dates'][0]['y']} |
-    | summary | {json_data['summary']} |
-    | id | {json_data['id']} |
-    | poster | ![poster](https:{json_data['cover']['url'].replace('/t_thumb/', '/t_cover_big/')}) |
-    """
+| Property | Value |
+| --- | --- |
+| title | {json_data['name']} |
+| year | {json_data['release_dates'][0]['y']} |
+| summary | {json_data['summary']} |
+| id | {json_data['id']} |
+| poster | ![poster](https:{json_data['cover']['url'].replace('/t_thumb/', '/t_cover_big/')}) |
+"""
                 with open("comment.md", "a") as comment_f:
                     comment_f.write(issue_comment)
 
@@ -244,7 +244,7 @@ def process_igdb_id(game_slug: Optional[str] = None,
             os.makedirs(name=destination_dir, exist_ok=True)  # create directory if it doesn't exist
 
             with open(destination_file, "w") as dest_f:
-                dest_f.write(json.dumps(og_data))
+                json.dump(obj=og_data, indent=4, fp=dest_f, sort_keys=True)
 
     return og_data
 
@@ -283,14 +283,14 @@ def process_tmdb_id(tmdb_id: int, youtube_url: Optional[str] = None) -> dict:
             if args.issue_update:
                 # create the issue comment and title files
                 issue_comment = f"""
-    | Property | Value |
-    | --- | --- |
-    | title | {json_data['title']} |
-    | year | {json_data['release_date'][0:4]} |
-    | summary | {json_data['overview']} |
-    | id | {json_data['id']} |
-    | poster | ![poster](https://image.tmdb.org/t/p/w185{json_data['poster_path']}) |
-    """
+| Property | Value |
+| --- | --- |
+| title | {json_data['title']} |
+| year | {json_data['release_date'][0:4]} |
+| summary | {json_data['overview']} |
+| id | {json_data['id']} |
+| poster | ![poster](https://image.tmdb.org/t/p/w185{json_data['poster_path']}) |
+"""
                 with open("comment.md", "a") as comment_f:
                     comment_f.write(issue_comment)
 
@@ -340,7 +340,7 @@ def process_tmdb_id(tmdb_id: int, youtube_url: Optional[str] = None) -> dict:
             os.makedirs(name=destination_dir, exist_ok=True)  # create directory if it doesn't exist
 
             with open(destination_file, "w") as dest_f:
-                dest_f.write(json.dumps(og_data))
+                json.dump(obj=og_data, indent=4, fp=dest_f, sort_keys=True)
 
     return og_data
 
@@ -363,7 +363,7 @@ def update_contributor_info(original: bool, base_dir: str):
                 contributor_data[os.environ['ISSUE_AUTHOR_USER_ID']]['items_edited'] += 1
 
     with open(contributor_file_path, 'w') as contributor_f:
-        json.dump(contributor_data, contributor_f)
+        json.dump(obj=contributor_data, indent=4, fp=contributor_f, sort_keys=True)
 
 
 def process_issue_update():
@@ -480,9 +480,9 @@ if __name__ == '__main__':
         queue.join()
 
         all_games_file = os.path.join('database', 'games', 'igdb', 'all.json')
-        with open(file=all_games_file, mode='w') as f:
-            f.write(json.dumps(all_games_dict))
+        with open(file=all_games_file, mode='w') as all_games_f:
+            json.dump(obj=all_games_dict, fp=all_games_f, sort_keys=True)
 
         all_movies_file = os.path.join('database', 'movies', 'themoviedb', 'all.json')
-        with open(file=all_movies_file, mode='w') as f:
-            f.write(json.dumps(all_movies_dict))
+        with open(file=all_movies_file, mode='w') as all_movies_f:
+            json.dump(obj=all_movies_dict, fp=all_movies_f, sort_keys=True)


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- issue comment formatting was inadvertently broken by a re-indent
- format json files with 4 indents, except `all.json`

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
