### PR TITLE
database: remove workflow concurrency

### DIFF
--- a/.github/workflows/auto-update-db.yml
+++ b/.github/workflows/auto-update-db.yml
@@ -4,9 +4,13 @@ on:
   issues:
     types: [labeled]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.label.name }}
-  cancel-in-progress: false  # false to act as queue
+# no point in concurrency since it still cancels pending jobs
+# concurrency:
+#   # only if label starts with "request" then add issue number to end of group
+#   group: >-
+#     ${{ github.workflow }}-${{ github.event.label.name }}
+#     ${{ startsWith(github.event.label.name, 'request-') | github.event.issue.number }}
+#   cancel-in-progress: false  # false to act as queue
 
 jobs:
   auto_update_db:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Cannot use concurrency since it still cancels pending jobs.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
