### PR TITLE
ci(auto-update-db): close and lock issue with github cli

### DIFF
--- a/.github/workflows/auto-update-db.yml
+++ b/.github/workflows/auto-update-db.yml
@@ -203,17 +203,12 @@ jobs:
         if: >-
           startsWith(github.event.label.name, 'add-') &&
           steps.update.outputs.exception == 'false'
-        uses: peter-evans/close-issue@v2
-        with:
-          close-reason: completed
-          comment: |
-            This theme has been added/updated and will be available on the next daily scheduled update.
-          token: ${{ secrets.GH_BOT_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+        run: |
+          comment="This theme has been added/updated and will be available on the next daily scheduled update."
+          close_reason="completed"
+          lock_reason="resolved"
 
-      - name: Lock Issue
-        if: >-
-          startsWith(github.event.label.name, 'add-') &&
-          steps.update.outputs.exception == 'false'
-        uses: OSDKDev/lock-issues@v1.1
-        with:
-          repo-token: ${{ secrets.GH_BOT_TOKEN }}
+          gh issue close ${{ github.event.issue.number }} --comment "${comment}" --reason "${close_reason}"
+          gh issue lock ${{ github.event.issue.number }} --reason "${lock_reason}"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Close and lock issue using GitHub cli instead of actions.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Replaces #1011 


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
