### PR TITLE
fix(issues): fix poster url when no poster

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -287,7 +287,7 @@ def process_item_id(item_type: str,
                     title = json_data['name']
                     issue_title = f"[GAME]: {title} ({json_data['release_dates'][0]['y']})"
                     year = json_data['release_dates'][0]['y']
-                    poster = f"https:{json_data['cover']['url'].replace('/t_thumb/', '/t_cover_big/')}"
+                    poster = f"![poster](https:{json_data['cover']['url'].replace('/t_thumb/', '/t_cover_big/')})"
                     summary = json_data['summary'].replace('\n', '<br>')
                 elif item_type == 'game_collection':
                     title = json_data['name']
@@ -299,12 +299,12 @@ def process_item_id(item_type: str,
                     title = json_data['title']
                     issue_title = f"[MOVIE]: {title} ({json_data['release_date'][0:4]})"
                     year = json_data['release_date'][0:4]
-                    poster = f"https://image.tmdb.org/t/p/w185{json_data['poster_path']}"
+                    poster = f"![poster](https://image.tmdb.org/t/p/w185{json_data['poster_path']})"
                     summary = json_data['overview'].replace('\n', '<br>')
                 elif item_type == 'movie_collection':
                     title = json_data['name']
                     issue_title = f"[MOVIE COLLECTION]: {title}"
-                    poster = f"https://image.tmdb.org/t/p/w185{json_data['poster_path']}"
+                    poster = f"![poster](https://image.tmdb.org/t/p/w185{json_data['poster_path']})"
                     summary = json_data['overview'].replace('\n', '<br>')
                 issue_comment = f"""
 | Property | Value |
@@ -313,7 +313,7 @@ def process_item_id(item_type: str,
 | year | {year} |
 | summary | {summary} |
 | id | {json_data['id']} |
-| poster | ![poster]({poster}) |
+| poster | {poster} |
 """
                 with open("comment.md", "a") as comment_f:
                     comment_f.write(issue_comment)


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fix poster url when poster url is empty.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
