### PR TITLE
fix(plots): remove space in plot filenames

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -624,9 +624,21 @@ if __name__ == '__main__':
                 cmd = 'orca'
             node_bin_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'node_modules', '.bin')
 
+            # clean up old files, a space was left in the file names
+            # todo - this can be removed after these files have been cleaned out of database branch
+            delete_files_list = [
+                f'{databases[db]["title"].lower()}_plot.json',
+                f'{databases[db]["title"].lower()}_plot.svg',
+            ]
+            for file in delete_files_list:
+                try:
+                    os.remove(os.path.join(os.path.dirname(databases[db]['path']), file))
+                except FileNotFoundError:
+                    pass
+
             # write fig to json file, orca fails with large json entered on command line
             json_file = os.path.join(os.path.dirname(databases[db]['path']),
-                                     f'{databases[db]["title"].lower()}_plot.json')
+                                     f'{databases[db]["title"].lower()}_plot.json'.replace(' ', '_'))
             with open(file=json_file, mode='w') as plot_f:
                 json.dump(obj=fig, fp=plot_f, cls=plotly.utils.PlotlyJSONEncoder)
 
@@ -635,7 +647,7 @@ if __name__ == '__main__':
                     os.path.join(node_bin_dir, cmd),
                     'graph', json_file,  # it's possible to pass in multiple json files here, but this is just one
                     '--output-dir', os.path.dirname(databases[db]['path']),
-                    '--output', f'{databases[db]["title"].lower()}_plot',
+                    '--output', f'{databases[db]["title"].lower()}_plot'.replace(' ', '_'),
                     '--format', 'svg'
                 ]
             )


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Removes space in plot file names, which will fix an issue with the readme. This will also remove the existing files on the next update.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
