### PR TITLE
tests: allow skipping tests that require secrets

### DIFF
--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -63,6 +63,10 @@ jobs:
           TMDB_API_KEY_V3: ${{ secrets.TMDB_API_KEY_V3 }}
           TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
           TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
+        if:  # only for an internal pull request or a push
+          (github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository) ||
+          (github.event_name == 'push' && github.ref == 'refs/heads/master')
         run: |
           # get daily movies list from tmdb
           # wget https://files.tmdb.org/p/exports/movie_ids_${{ steps.date.outputs.tmdb_date }}.json.gz \

--- a/src/updater.py
+++ b/src/updater.py
@@ -130,10 +130,10 @@ def igdb_authorization(client_id: str, client_secret: str) -> dict:
 
 # setup igdb authorization and wrapper
 auth = igdb_authorization(
-    client_id=os.environ["TWITCH_CLIENT_ID"],
-    client_secret=os.environ["TWITCH_CLIENT_SECRET"]
+    client_id=os.getenv("TWITCH_CLIENT_ID"),
+    client_secret=os.getenv("TWITCH_CLIENT_SECRET")
 )
-wrapper = IGDBWrapper(client_id=os.environ["TWITCH_CLIENT_ID"], auth_token=auth['access_token'])
+wrapper = IGDBWrapper(client_id=os.getenv("TWITCH_CLIENT_ID"), auth_token=auth.get('access_token'))
 
 
 def requests_loop(url: str,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,27 @@ load_dotenv()
 os.environ['ISSUE_AUTHOR_USER_ID'] = '1234'
 
 
+@pytest.fixture(scope='session')
+def igdb_auth():
+    """Skip tests if no auth id or secret."""
+    auth_id = os.getenv('TWITCH_CLIENT_ID')
+    auth_secret = os.getenv('TWITCH_CLIENT_SECRET')
+
+    if not auth_id or not auth_secret:
+        # skip if no auth id or secret
+        pytest.skip('"TWITCH_CLIENT_ID" or "TWITCH_CLIENT_SECRET" not set in environment variables.')
+
+
+@pytest.fixture(scope='session')
+def tmdb_auth():
+    """Skip tests if no api key."""
+    auth_id = os.getenv('TMDB_API_KEY_V3')
+
+    if not auth_id:
+        # skip if no api key
+        pytest.skip('"TMDB_API_KEY_V3" not set in environment variables.')
+
+
 @pytest.fixture(scope='function')
 def daily_update_args():
     parser = updater.parse_args(['--daily_update'])

--- a/tests/unit/test_issue_updater.py
+++ b/tests/unit/test_issue_updater.py
@@ -18,7 +18,7 @@ from src import updater
 sample_youtube_url = 'https://www.youtube.com/watch?v=qGPBFvDz_HM'
 
 
-def test_igdb_authorization():
+def test_igdb_authorization(igdb_auth):
     """Tests if access token is returned from igdb_authorization method."""
     auth = updater.igdb_authorization(
         client_id=os.environ["TWITCH_CLIENT_ID"],
@@ -28,7 +28,7 @@ def test_igdb_authorization():
     assert auth['access_token']
 
 
-def test_process_issue_update(issue_update_args):
+def test_process_issue_update(issue_update_args, igdb_auth, tmdb_auth):
     """Test the provides submission urls and verify they are the correct item type."""
     database_urls = [
         # url, expected item type
@@ -56,7 +56,7 @@ def test_check_youtube():
     assert scheme == 'https'
 
 
-def test_process_item_id_game_by_slug():
+def test_process_item_id_game_by_slug(igdb_auth):
     """Tests if the provided game_slug is valid and the created dictionary contains the required keys."""
     data = updater.process_item_id(
         item_type='game',
@@ -68,7 +68,7 @@ def test_process_item_id_game_by_slug():
     assert data['youtube_theme_url']
 
 
-def test_process_item_id_game_by_id():
+def test_process_item_id_game_by_id(igdb_auth):
     """Tests if the provided game_id is valid and the created dictionary contains the required keys."""
     data = updater.process_item_id(
         item_type='game',
@@ -80,7 +80,7 @@ def test_process_item_id_game_by_id():
     assert data['youtube_theme_url']
 
 
-def test_process_item_id_game_collection_by_slug():
+def test_process_item_id_game_collection_by_slug(igdb_auth):
     """Tests if the provided game_slug is valid and the created dictionary contains the required keys."""
     data = updater.process_item_id(
         item_type='game_collection',
@@ -92,7 +92,7 @@ def test_process_item_id_game_collection_by_slug():
     assert data['youtube_theme_url']
 
 
-def test_process_item_id_game_collection_by_id():
+def test_process_item_id_game_collection_by_id(igdb_auth):
     """Tests if the provided game_id is valid and the created dictionary contains the required keys."""
     data = updater.process_item_id(
         item_type='game_collection',
@@ -104,7 +104,7 @@ def test_process_item_id_game_collection_by_id():
     assert data['youtube_theme_url']
 
 
-def test_process_item_id_game_franchise_by_slug():
+def test_process_item_id_game_franchise_by_slug(igdb_auth):
     """Tests if the provided game_slug is valid and the created dictionary contains the required keys."""
     data = updater.process_item_id(
         item_type='game_franchise',
@@ -116,7 +116,7 @@ def test_process_item_id_game_franchise_by_slug():
     assert data['youtube_theme_url']
 
 
-def test_process_item_id_game_franchise_by_id():
+def test_process_item_id_game_franchise_by_id(igdb_auth):
     """Tests if the provided game_id is valid and the created dictionary contains the required keys."""
     data = updater.process_item_id(
         item_type='game_franchise',
@@ -128,7 +128,7 @@ def test_process_item_id_game_franchise_by_id():
     assert data['youtube_theme_url']
 
 
-def test_process_item_id_movie():
+def test_process_item_id_movie(tmdb_auth):
     """Tests if the provided movie is valid and the created dictionary contains the required keys."""
     data = updater.process_item_id(
         item_type='movie',
@@ -140,7 +140,7 @@ def test_process_item_id_movie():
     assert data['youtube_theme_url']
 
 
-def test_process_item_id_movie_collection():
+def test_process_item_id_movie_collection(tmdb_auth):
     """Tests if the provided movie collection is valid and the created dictionary contains the required keys."""
     data = updater.process_item_id(
         item_type='movie_collection',
@@ -152,11 +152,11 @@ def test_process_item_id_movie_collection():
     assert data['youtube_theme_url']
 
 
-def test_main_daily_update(daily_update_args):
+def test_main_daily_update(daily_update_args, igdb_auth, tmdb_auth):
     updater.main()
 
 
-def test_main_issue_update_movie(issue_update_args, submission_movie):
+def test_main_issue_update_movie(issue_update_args, submission_movie, tmdb_auth):
     updater.main()
     file_path = os.path.join(os.getcwd(), 'database', 'movies', 'themoviedb', '10378.json')
 
@@ -169,7 +169,7 @@ def test_main_issue_update_movie(issue_update_args, submission_movie):
     assert data['youtube_theme_url'] == submission_movie['youtube_theme_url']
 
 
-def test_main_issue_update_game(issue_update_args, submission_game):
+def test_main_issue_update_game(issue_update_args, submission_game, igdb_auth):
     updater.main()
     file_path = os.path.join(os.getcwd(), 'database', 'games', 'igdb', '1638.json')
 
@@ -182,7 +182,7 @@ def test_main_issue_update_game(issue_update_args, submission_game):
     assert data['youtube_theme_url'] == submission_game['youtube_theme_url']
 
 
-def test_main_issue_update_movie_collection(issue_update_args, submission_movie_collection):
+def test_main_issue_update_movie_collection(issue_update_args, submission_movie_collection, tmdb_auth):
     updater.main()
     file_path = os.path.join(os.getcwd(), 'database', 'movie_collections', 'themoviedb', '645.json')
 
@@ -195,7 +195,7 @@ def test_main_issue_update_movie_collection(issue_update_args, submission_movie_
     assert data['youtube_theme_url'] == submission_movie_collection['youtube_theme_url']
 
 
-def test_main_issue_update_game_collection(issue_update_args, submission_game_collection):
+def test_main_issue_update_game_collection(issue_update_args, submission_game_collection, igdb_auth):
     updater.main()
     file_path = os.path.join(os.getcwd(), 'database', 'game_collections', 'igdb', '326.json')
 
@@ -208,7 +208,7 @@ def test_main_issue_update_game_collection(issue_update_args, submission_game_co
     assert data['youtube_theme_url'] == submission_game_collection['youtube_theme_url']
 
 
-def test_main_issue_update_game_franchise(issue_update_args, submission_game_franchise):
+def test_main_issue_update_game_franchise(issue_update_args, submission_game_franchise, igdb_auth):
     updater.main()
     file_path = os.path.join(os.getcwd(), 'database', 'game_franchises', 'igdb', '37.json')
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Allow skipping tests that require secrets. This is a temporary fix, but ideally we would like a way to provide our secrets to fork external PRs.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
