### PR TITLE
feat: allow playlist urls

### DIFF
--- a/tests/unit/test_issue_updater.py
+++ b/tests/unit/test_issue_updater.py
@@ -48,9 +48,13 @@ def test_process_issue_update(db_url, db_type, issue_update_args, igdb_auth, tmd
     assert data == db_type
 
 
-def test_check_youtube(youtube_url):
+@pytest.mark.parametrize('url_suffix', [
+    '',
+    '&list=PLE0hg-LdSfycrpTtMImPSqFLle4yYNzWD',
+])
+def test_check_youtube(youtube_url, url_suffix):
     """Tests if the provided YouTube url is valid and returns a valid url."""
-    yt_url = updater.check_youtube(data=dict(youtube_theme_url=youtube_url))
+    yt_url = updater.check_youtube(data=dict(youtube_theme_url=f'{youtube_url}{url_suffix}'))
 
     host = urlparse(yt_url).hostname
     scheme = urlparse(yt_url).scheme


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Allow YouTube URL in issue body to be a playlist.

Todo:
- [x] Add/update tests


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
