### PR TITLE
feat: automatically re-label edited issues

### DIFF
--- a/.github/workflows/Relabel_issue.yml
+++ b/.github/workflows/Relabel_issue.yml
@@ -1,0 +1,68 @@
+---
+name: Relabel Issue
+on:
+  issues:
+    types: [edited]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+
+jobs:
+  relabel_issue:
+    name: Relabel issue ${{ github.event.issue.number }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Relabel issue ${{ github.event.issue.number }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_BOT_TOKEN }}
+          script: |
+            // get labels
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            })
+
+            // list of labels to permanently remove
+            const labels_remove = ["approve-theme", "approve-queue"]
+
+            // check if labels list contains any of the labels to remove
+            for (const label of labels_remove) {
+              const label_remove = labels.data.some(label => label.name === label)
+              if (label_remove) {
+                github.rest.issues.removeLabel({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: [label]
+                })
+              }
+            }
+
+            // check if labels list contains "request-theme"
+            const request_label = "request-theme"
+            const label_request = labels.data.some(label => label.name === request_label)
+
+            // remove label if label exists
+            if (label_request) {
+              github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: [request_label]
+              })
+            }
+
+            // add label if it existed before
+            if (label_exception) {
+              github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: [request_label]
+              })
+            }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR adds a new workflow which will run when issues are edited. The workflow will do the following.

- Remove `approve-queue` and/or `approve-theme` labels.
- Remove `request-theme` label and re-apply it... thus re-running the initial check.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
