### PR TITLE
feat: remove question label and add edited label on issue edit

### DIFF
--- a/.github/workflows/Relabel_issue.yml
+++ b/.github/workflows/Relabel_issue.yml
@@ -26,7 +26,7 @@ jobs:
             })
 
             // list of labels to permanently remove
-            const labels_remove = ["approve-theme", "approve-queue"]
+            const labels_remove = ["approve-theme", "approve-queue", "question"]
 
             // check if labels list contains any of the labels to remove
             for (var label_name of labels_remove) {
@@ -58,12 +58,17 @@ jobs:
             // add a delay to allow the label to be removed before trying to re-add it
             await new Promise(r => setTimeout(r, 10000));
 
+            // labels to add list
+            var labels_add = ["edited"]
+
             // add label if it existed before, this will re-trigger another workflow
             if (label_request) {
-              github.rest.issues.addLabels({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                labels: [request_label]
-              })
+              labels_add.push(request_label)
             }
+
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: labels_add
+            })


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Automatically remove `question` label when an issue is edited.
- Add an `edited` label when an issue is edited.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
