### PR TITLE
fix: skip relabel on edits by bot

### DIFF
--- a/.github/workflows/Relabel_issue.yml
+++ b/.github/workflows/Relabel_issue.yml
@@ -13,7 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # we want to skip edits made by the bot (especially title edits)
+      - name: Get Actor
+        id: get_actor
+        run: |
+          echo "actor=${{ github.actor }}" >> $GITHUB_OUTPUT
+
       - name: Relabel issue ${{ github.event.issue.number }}
+        if: ${{ steps.get_actor.outputs.actor != 'LizardByte-bot' }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
When an issue is created without a title, the bot would edit the title... thus triggering the labels to re-applied. This PR will check if the edits were made by the bot, and skip them if the workflow if they were.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
