### PR TITLE
fix: re-apply request label on comment command edit

### DIFF
--- a/.github/workflows/Comment_command.yml
+++ b/.github/workflows/Comment_command.yml
@@ -76,13 +76,7 @@ jobs:
             // approve
             if (args[1] === "approve") {
               console.log("approve command running")
-              // add label "approve-queue"
-              github.rest.issues.addLabels({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                labels: ["approve-queue"]
-              })
+              let labelsToAdd = ["approve-queue"]
 
               // get list of open issues with label "approve-theme"
               const running_issues = await github.rest.issues.listForRepo({
@@ -93,18 +87,22 @@ jobs:
               })
 
               // add approve-theme label if no other issues have it
-              if (issues.data.length === 0) {
+              if (running_issues.data.length === 0) {
                 console.log("no other issues have approve-theme label, adding label")
-                github.rest.issues.addLabels({
-                  issue_number: context.issue.number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  labels: ["approve-theme"]
-                })
+                labelsToAdd.push("approve-theme")
               }
               else {
                 console.log("other issues have approve-theme label, not adding label")
               }
+
+              console.log(`Adding labels: ${labelsToAdd}`)
+              github.rest.issues.addLabels({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: labelsToAdd
+              })
+
               command_ran = true
             }
 
@@ -112,25 +110,64 @@ jobs:
             if (args[1] === "edit") {
               console.log("edit command running")
               // replace youtube url in issue body
-              let issue_body = `${ISSUE_BODY}`
+              let og_issue_body = `${ISSUE_BODY}`
               console.log(`issue_body: ${issue_body}`)
 
-              let current_url = issue_body.match(YT_REGEX)
+              let current_url = og_issue_body.match(YT_REGEX)
               console.log(`current_url: ${current_url}`)
 
               // if current_url is not null
               if (current_url !== null) {
               // replace current_url with args[2]
-                issue_body = issue_body.replace(current_url[0], args[2])
+                let issue_body = og_issue_body.replace(current_url[0], args[2])
                 console.log(`updated issue_body: ${issue_body}`)
 
-                // update issue body
-                github.rest.issues.update({
-                  issue_number: context.issue.number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  body: issue_body
-                })
+                if (issue_body !== og_issue_body) {
+                  // update issue body
+                  github.rest.issues.update({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    body: issue_body
+                  })
+
+                  // re-apply labels since the relabeler ignores edits from LizardByte-bot
+
+                  // get labels
+                  const labels = await github.rest.issues.listLabelsOnIssue({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo
+                  })
+
+                  // list of labels to permanently remove
+                  const labels_remove = ["approve-theme", "approve-queue", "request-theme"]
+
+                  // check if labels list contains any of the labels to remove
+                  for (var label_name of labels_remove) {
+                    var label_remove = labels.data.some(label => label.name === label_name)
+                    if (label_remove) {
+                      github.rest.issues.removeLabel({
+                        issue_number: context.issue.number,
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        name: [label_name]
+                      })
+                    }
+                  }
+
+                  // add a delay to allow the label to be removed before trying to re-add it
+                  await new Promise(r => setTimeout(r, 10000))
+
+                  // re-add request-theme label
+                  github.rest.issues.addLabels({
+                    issue_number: context.issue.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    labels: ["request-theme"]
+                  })
+
+                }
               }
               command_ran = true
             }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- re-apply request label on comment command edits in order to trigger new workflow run
- fix undeclared variable issue on approve command
- reduce number of api calls to add `approve-queue` and `approve-theme` labels
- only edit issue if body actually changes


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
