### PR TITLE
feat: handle duplicate submissions

### DIFF
--- a/.github/workflows/auto-update-db.yml
+++ b/.github/workflows/auto-update-db.yml
@@ -81,6 +81,20 @@ jobs:
               echo "exception=false" >> $GITHUB_OUTPUT
           fi
 
+          # if duplicate.md file exists, then set output to true
+          if [ -f duplicate.md ]; then
+              echo "duplicate=true" >> $GITHUB_OUTPUT
+          else
+              echo "duplicate=false" >> $GITHUB_OUTPUT
+          fi
+
+          # if auto_close.md file exists, then set output to true
+          if [ -f auto_close.md ]; then
+              echo "auto_close=true" >> $GITHUB_OUTPUT
+          else
+              echo "auto_close=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Git Diff
         id: diff
         working-directory: database
@@ -130,57 +144,64 @@ jobs:
               repo: context.repo.repo
             })
 
-            // get exception output
+            // get update outputs
             const exception = "${{ steps.update.outputs.exception }}"
+            const duplicate = "${{ steps.update.outputs.duplicate }}"
+
+            // create an array of current labels
+            let current_labels = labels.data.map(label => label.name)
 
             // check if labels list contains "exception"
-            const label_exception = labels.data.some(label => label.name === 'exception')
+            const label_exception = current_labels.includes('exception')
 
             // add exception label if there was an exception and not already labeled
             if (!label_exception && exception === 'true') {
-              github.rest.issues.addLabels({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                labels: ['exception']
-              })
+              current_labels.push('exception')
+            } else if (label_exception && exception === 'false') {
+              // remove exception label if there is no longer an exception
+              const index = current_labels.indexOf('exception')
+              current_labels.splice(index, 1)
             }
 
-            // remove exception label if there is no longer an exception
-            if (label_exception && exception === 'false') {
-              github.rest.issues.removeLabel({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: ['exception']
-              })
+            // check if labels list contains "duplicate"
+            const label_duplicate = current_labels.includes('duplicate')
+
+            // add duplicate label if there was a duplicate and not already labeled
+            if (!label_duplicate && duplicate === 'true') {
+              current_labels.push('duplicate')
+            } else if (label_duplicate && duplicate === 'false') {
+              // remove duplicate label if there is no longer a duplicate
+              const index = current_labels.indexOf('duplicate')
+              current_labels.splice(index, 1)
             }
 
             // check if labels list contains "approve-theme"
             const approve_label = "approve-theme"
 
-            let label_add = labels.data.some(label => label.name === approve_label)
+            let label_add = current_labels.includes(approve_label)
             if (label_add && exception === 'true') {
-              github.rest.issues.removeLabel({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: [approve_label]
-              })
+              // remove approve-theme label if there is an exception
+              const index = current_labels.indexOf(approve_label)
+              current_labels.splice(index, 1)
             }
 
             // remove label "approve-queue"
             const queue_label = "approve-queue"
 
-            let label_remove = labels.data.some(label => label.name === queue_label)
+            // this is always removed
+            let label_remove = current_labels.includes(queue_label)
             if (label_remove) {
-              github.rest.issues.removeLabel({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: [queue_label]
-              })
+              const index = current_labels.indexOf(queue_label)
+              current_labels.splice(index, 1)
             }
+
+            // set labels
+            await github.rest.issues.setLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: current_labels
+            })
 
             // determine to continue or not
             if (label_add) {
@@ -192,6 +213,20 @@ jobs:
         with:
           repo-token: ${{ secrets.GH_BOT_TOKEN }}
           message-path: comment.md
+
+      - name: Auto Close
+        if: >-
+          (github.event.label.name == 'request-theme') &&
+          steps.update.outputs.auto_close == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+        run: |
+          comment=$(cat auto_close.md)
+          close_reason="not_planned"
+          lock_reason="resolved"
+
+          gh issue close ${{ github.event.issue.number }} --comment "${comment}" --reason "${close_reason}"
+          gh issue lock ${{ github.event.issue.number }} --reason "${lock_reason}"
 
       - name: GitHub Commit & Push
         if: >-

--- a/.gitignore
+++ b/.gitignore
@@ -169,7 +169,9 @@ gh-pages-template/games/
 gh-pages-template/movies/
 
 # files from issue upating
+auto_close.md
 comment.md
+duplicate.md
 exceptions.md
 title.md
 

--- a/src/updater.py
+++ b/src/updater.py
@@ -154,7 +154,7 @@ def requests_loop(url: str,
                   allow_statuses: list = [requests.codes.ok]) -> requests.Response:
     count = 1
     while count <= max_tries:
-        print(f'Processing {url} ... (attempt {count + 1} of {max_tries})')
+        print(f'Processing {url} ... (attempt {count} of {max_tries})')
         try:
             response = method(url=url, headers=headers)
         except requests.exceptions.RequestException as e:
@@ -277,6 +277,10 @@ def process_item_id(item_type: str,
 
     item_file = os.path.join(database_path, f"{item_id}.json")
     if os.path.isfile(item_file):
+        if args.issue_update:
+            with open("duplicate.md", "w") as duplicate_f:
+                duplicate_f.write('This item already exists in the database.')
+
         with open(file=item_file, mode='r') as og_f:
             og_data = json.load(fp=og_f)  # get currently saved data
 
@@ -366,6 +370,11 @@ def process_item_id(item_type: str,
                 update_contributor_info(original=original_submission,
                                         base_dir=databases[item_type]['path'])
 
+                # check if youtube_theme_url is the same as before
+                if og_data.get('youtube_theme_url') == youtube_url:
+                    with open("auto_close.md", "w") as auto_close_f:
+                        auto_close_f.write('The YouTube url provided is the same as the current one.')
+
         # update the existing dictionary with new values from json_data
         og_data.update(json_data)
         if youtube_url:
@@ -444,7 +453,7 @@ def process_issue_update(database_url: Optional[str] = None, youtube_url: Option
         if not database_url:
             database_url = submission['database_url'].strip()
 
-        # check validity of provided YouTube url and update item dictionary
+        # check the validity of provided YouTube url and update item dictionary
         if not youtube_url:
             youtube_url = check_youtube(data=submission)
 

--- a/tests/unit/test_issue_updater.py
+++ b/tests/unit/test_issue_updater.py
@@ -43,7 +43,7 @@ def test_igdb_authorization(igdb_auth):
     ('https://www.themoviedb.org/tv/1930-the-beverly-hillbillies', 'tv_show'),
 ])
 def test_process_issue_update(db_url, db_type, issue_update_args, igdb_auth, tmdb_auth, youtube_url):
-    """Test the provides submission urls and verify they are the correct item type."""
+    """Test the provided submission urls and verify they are the correct item type."""
     data = updater.process_issue_update(database_url=db_url, youtube_url=youtube_url)
 
     assert data == db_type


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Auto close exact duplicates
- Label duplicates where the theme changes
- Fix small bug where request retry count was off by one
- Use a single api request to set and remove the labels


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
