### PR TITLE
fix(auto_close): use correct argument for close reason

### DIFF
--- a/.github/workflows/auto-update-db.yml
+++ b/.github/workflows/auto-update-db.yml
@@ -222,7 +222,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         run: |
           comment=$(cat auto_close.md)
-          close_reason="not_planned"
+          close_reason="not planned"
           lock_reason="resolved"
 
           gh issue close ${{ github.event.issue.number }} --comment "${comment}" --reason "${close_reason}"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
argument should be "not planned", not "not_planned"

```txt
invalid argument "not_planned" for "-r, --reason" flag: valid values are {completed|not planned}
Usage:  gh issue close {<number> | <url>} [flags]
Flags:
  -c, --comment string   Leave a closing comment
  -r, --reason string    Reason for closing: {completed|not planned}
```

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
