### PR TITLE
fix(request): process item url unconditionally

### DIFF
--- a/src/updater.py
+++ b/src/updater.py
@@ -444,6 +444,7 @@ def update_contributor_info(original: bool, base_dir: str) -> None:
 def process_issue_update(database_url: Optional[str] = None, youtube_url: Optional[str] = None) -> Union[str, bool]:
     # placeholders
     exceptions = []
+    youtube_valid = False
 
     # process submission file if required (always required except for tests)
     if not database_url or not youtube_url:
@@ -457,9 +458,10 @@ def process_issue_update(database_url: Optional[str] = None, youtube_url: Option
         if not youtube_url:
             youtube_url = check_youtube(data=submission)
 
-    if not youtube_url:
+    if youtube_url:
+        youtube_valid = True
+    else:
         exception_writer(error=Exception('Error processing YouTube url'), name='youtube', end_program=False)
-        return False
 
     # regex map
     regex_map = {
@@ -479,7 +481,7 @@ def process_issue_update(database_url: Optional[str] = None, youtube_url: Option
             exceptions.append((item_type, e))
         else:
             process_item_id(item_type=item_type, item_id=item_id, youtube_url=youtube_url)
-            return item_type
+            return item_type if youtube_valid else False
 
     # if we get here, we didn't find a match
     for exception in exceptions:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
https://github.com/LizardByte/ThemerrDB/pull/4250 was not a proper fix. Hopefully this one will be better.

Current situation:

Update step:
```txt
[youtube] Extracting URL: https://www.youtube.com/watch?v=fM-_T6jXS7U
[youtube] fM-_T6jXS7U: Downloading webpage
[youtube] fM-_T6jXS7U: Downloading ios player API JSON
ERROR: [youtube] fM-_T6jXS7U: Video unavailable. This video contains content from NBC Universal, who has blocked it in your country on copyright grounds
Error processing youtube: ERROR: [youtube] fM-_T6jXS7U: Video unavailable. This video contains content from NBC Universal, who has blocked it in your country on copyright grounds
Error processing youtube: Error processing YouTube url
```

Git diff step:
```txt
  cat: ../title.md: No such file or directory
  Error: Process completed with exit code 1.
```


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
